### PR TITLE
clock-container changed from flexbox to flex

### DIFF
--- a/Theme Clock/style.css
+++ b/Theme Clock/style.css
@@ -49,7 +49,7 @@ body {
 }
 
 .clock-container {
-  display: flexbox;
+  display: flex;
   flex-direction: column;
   justify-content: space-between;
   align-items: center;


### PR DESCRIPTION
incorrectly displayed as flexbox cause the .date div to not be centered